### PR TITLE
🔄 Update NixOS Flake Dependencies

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -209,11 +209,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769132734,
-        "narHash": "sha256-gmU9cRplrQWqoback9PgQX7Dlsdx8JlhlVZwf0q1F7E=",
+        "lastModified": 1769187349,
+        "narHash": "sha256-clG+nT6I2qxjIgk5WoSDKJyNhzKJs9jzbCujPF2S/yg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d055b309a6277343cb1033a11d7500f0a0f669fc",
+        "rev": "082a4cd87c6089d1d9c58ebe52655f9e07245fcb",
         "type": "github"
       },
       "original": {
@@ -474,11 +474,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1769169644,
-        "narHash": "sha256-4Ow/7MeM2zdDl7BSP1otnVx3CaSpSNgy2ph/fKz2DNc=",
+        "lastModified": 1769204633,
+        "narHash": "sha256-B8+OiD8kYXtFc4vJc9+d7q8+MOic8VYR0G8wbSHjuSc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "257523782c065a2ea66c9e765cbc7c6ecca132f2",
+        "rev": "bea55329cc806cfe3b826f7baab0503fd6b6892f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Automated Flake Lockfile Update

This PR tracks rolling updates to `flake.lock`.

### Latest Update
- **agenix**: ryantm/agenix (fcdea22)
- **darwin**: lnl7/nix-darwin (43975d7)
- **flake-parts**: hercules-ci/flake-parts (80daad0)
- **flake-parts_2**: hercules-ci/flake-parts (a34fae9)
- **flake-parts_3**: hercules-ci/flake-parts (205b12d)
- **flake-utils**: numtide/flake-utils (11707dc)
- **flake-utils_2**: numtide/flake-utils (11707dc)
- **flake-utils_3**: numtide/flake-utils (11707dc)
- **home-manager**: nix-community/home-manager (abfad3d)
- **home-manager-stable**: nix-community/home-manager (75ed713)
- **home-manager-unstable**: nix-community/home-manager (082a4cd)
- **ixx**: NuschtOS/ixx (babfe85)
- **nix-vscode-extensions**: nix-community/nix-vscode-extensions (969bb9a)
- **nixgl-stable**: guibou/nixGL (b610529)
- **nixgl-unstable**: guibou/nixGL (b610529)
- **nixos-hardware**: nixos/nixos-hardware (9f7ba89)
- **nixpkgs**: NixOS/nixpkgs (59e6964)
- **nixpkgs-stable**: nixos/nixpkgs (078d69f)
- **nixpkgs-unstable**: nixos/nixpkgs (88d3861)
- **nixpkgs_2**: nixos/nixpkgs (def3da6)
- **nixpkgs_3**: nixos/nixpkgs (88d3861)
- **nixpkgs_4**: nixos/nixpkgs (88d3861)
- **nixvim-stable**: nix-community/nixvim (b8f76bf)
- **nixvim-unstable**: nix-community/nixvim (5b138ed)
- **nur**: nix-community/NUR (bea5532)
- **nuschtosSearch**: NuschtOS/search (b6f77b8)
- **plasma-manager-stable**: pjones/plasma-manager (51816be)
- **plasma-manager-unstable**: pjones/plasma-manager (51816be)
- **systems**: nix-systems/default (da67096)
- **systems_2**: nix-systems/default (da67096)
- **systems_3**: nix-systems/default (da67096)
- **systems_4**: nix-systems/default (da67096)
- **systems_5**: nix-systems/default (da67096)
- **systems_6**: nix-systems/default (da67096)

### Required Testing

- [ ] **kairos** - `sudo nixos-rebuild switch --flake .#kairos`
- [ ] **echo** - `sudo nixos-rebuild switch --flake .#echo`
- [ ] **sky** - `sudo nixos-rebuild switch --flake .#sky`

This PR is force-updated on every run.