### PR TITLE
Add scoped polkit rule for wheel login1 actions

### DIFF
--- a/hosts/configuration.nix
+++ b/hosts/configuration.nix
@@ -72,6 +72,25 @@ in {
   security = {
     rtkit.enable = true;
     polkit.enable = true;
+    polkit.extraConfig = ''
+      polkit.addRule(function (action, subject) {
+        if (
+          subject.isInGroup("wheel") &&
+          (
+            action.id == "org.freedesktop.login1.power-off" ||
+            action.id == "org.freedesktop.login1.power-off-multiple-sessions" ||
+            action.id == "org.freedesktop.login1.reboot" ||
+            action.id == "org.freedesktop.login1.reboot-multiple-sessions" ||
+            action.id == "org.freedesktop.login1.suspend" ||
+            action.id == "org.freedesktop.login1.suspend-multiple-sessions" ||
+            action.id == "org.freedesktop.login1.hibernate" ||
+            action.id == "org.freedesktop.login1.hibernate-multiple-sessions"
+          )
+        ) {
+          return polkit.Result.AUTH_SELF_KEEP;
+        }
+      });
+    '';
     sudo.wheelNeedsPassword = false;
   };
 


### PR DESCRIPTION
### Motivation
- Allow members of the `wheel` group to authenticate common session/power actions without requiring the root password while keeping the rule scoped to specific `org.freedesktop.login1.*` actions to avoid an over-permissive blanket allow.
- Ensure desktop actions like reboot/power-off/suspend/hibernate authenticate against the invoking user's password (if required) rather than root.

### Description
- Added a `security.polkit.extraConfig` block in `hosts/configuration.nix` that registers a polkit rule matching `subject.isInGroup("wheel")` and specific `org.freedesktop.login1.*` action IDs and returns `polkit.Result.AUTH_SELF_KEEP` to allow users to authenticate with their own password.
- The rule explicitly covers `power-off`, `power-off-multiple-sessions`, `reboot`, `reboot-multiple-sessions`, `suspend`, `suspend-multiple-sessions`, `hibernate`, and `hibernate-multiple-sessions`.
- Kept existing `sudo.wheelNeedsPassword = false` unchanged and updated only `hosts/configuration.nix`.

### Testing
- The change was staged and committed successfully with a local `git commit` operation that completed without error.
- No automated NixOS rebuild or runtime tests were executed in this environment, so runtime behavior (GDM prompts) was not verified automatically.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69892798700083338bfae6093c9b6b9a)